### PR TITLE
Add additional items for RAID array detection

### DIFF
--- a/lib/einarc/adaptec_aaccli.rb
+++ b/lib/einarc/adaptec_aaccli.rb
@@ -120,7 +120,7 @@ module Einarc
 		end
 
 		def logical_add(raid_level, discs = nil, sizes = nil, options = nil)
-			if discs 
+			if discs
 				discs = discs.split(/,/) if discs.respond_to?(:split)
 				discs = [discs] unless discs.respond_to?(:each)
 			else
@@ -295,7 +295,7 @@ module Einarc
 		def set_physical_hotspare_1(drv)
 			raise NotImplemented
 		end
-		
+
 		def get_logical_stripe(num)
 			ld = _logical_list[num.to_i]
 			raise Error.new("Unknown logical disc \"#{num}\"") unless ld
@@ -345,7 +345,7 @@ module Einarc
 		def _bbu_info
 			raise NotImplementedError
 		end
-		
+
 		# ======================================================================
 
 		private
@@ -390,7 +390,7 @@ module Einarc
 				"(#{$1.to_i},#{$2.to_i})"
 			else
 				raise Error.new("Unparseable physical disc specification: \"#{phys}\"")
-			end			
+			end
 		end
 
 		# Calculates coerced size: kB measurement, 64kB alignment

--- a/lib/einarc/autodetect.rb
+++ b/lib/einarc/autodetect.rb
@@ -32,7 +32,7 @@ module Einarc
 			vendor_id = $3
 			product_id = $4
 #			p [vendor_id, product_id]
-			adapter = find_adapter_by_pciid(vendor_id, product_id)
+			adapter = find_adapter_by_pciid(vendor_id, product_id, $6, $7)
 			if adapter
 				puts "Detected device supported by \"#{adapter}\" (#{vendor_id}:#{product_id})"
 				res << adapter

--- a/lib/einarc/baseraid.rb
+++ b/lib/einarc/baseraid.rb
@@ -42,6 +42,7 @@ module Einarc
 	# * Abstract methods that should be implemented in RAID adapter modules
 	# * Misc helper methods useful for all modules
 	class BaseRaid
+    @@sysfs = '/sys'
 		attr_accessor :logical
 		attr_accessor :physical
 		attr_accessor :outstream
@@ -112,7 +113,7 @@ module Einarc
 
 		def append_shortcuts(key)
 			shortcuts = SHORTCUTS[key]
-			if shortcuts && !shortcuts.empty? 
+			if shortcuts && !shortcuts.empty?
 				"#{ key } (#{ shortcuts.join(', ') })"
 			else
 				key
@@ -240,7 +241,7 @@ module Einarc
 				_physical_list.each_pair { |num, d|
 					@outstream.printf(
 						"%-8s%-25s%-15s%-20s%11.2f MB  %s\n",
-						num, d[:model], d[:revision], d[:serial], d[:size], 
+						num, d[:model], d[:revision], d[:serial], d[:size],
 							d[:state].is_a?(Array) ? d[:state].join(",") : d[:state]
 					)
 				}
@@ -398,7 +399,7 @@ module Einarc
 		def parse_smart_output(smart_output)
 			res = []
 			got_smart = false
-			needed_smart_section_re = /START OF READ SMART DATA SECTION/ 
+			needed_smart_section_re = /START OF READ SMART DATA SECTION/
 
 			smart_output.split(/\n/).each { |line|
 				got_smart = true if line =~ needed_smart_section_re

--- a/lib/einarc/baseraid.rb
+++ b/lib/einarc/baseraid.rb
@@ -3,8 +3,6 @@ module Einarc
 	# system dependent and 99.9% of Linux distributions won't have to
 	# change it. However, replace this one with fake sysfs comes handy
 	# for testing purposes too.
-  @@sysfs = '/sys'
-
 	class Error < RuntimeError
 		attr_reader :text
 
@@ -45,6 +43,7 @@ module Einarc
 		attr_accessor :logical
 		attr_accessor :physical
 		attr_accessor :outstream
+    attr_accessor :sysfs
 
 		SHORTCUTS = {
 			'adapter' => %w( ad ),
@@ -70,6 +69,7 @@ module Einarc
 
 		def initialize
 			@outstream = $stdout
+      @sysfs = '/sys'
 		end
 
 		def method_names
@@ -370,7 +370,7 @@ module Einarc
 		end
 
 		def find_dev_by_name(name)
-			for dir in Dir["#{@@sysfs}/block/*/device/"]
+			for dir in Dir["#{@sysfs}/block/*/device/"]
 				dev = dir.gsub(/^\/sys\/block/, '/dev').gsub(/\/device\/$/, '')
 				mpath = dir + 'model'
 				next unless File.readable?(mpath)
@@ -392,7 +392,7 @@ module Einarc
 
 		# Read single line from block device-related files in sysfs
 		def physical_read_file(device, source)
-			return sysfs_read_file("#{@@sysfs}/block/#{device.gsub(/^\/dev\//, '')}/#{source}")
+			return sysfs_read_file("#{@sysfs}/block/#{device.gsub(/^\/dev\//, '')}/#{source}")
 		end
 
 		def parse_smart_output(smart_output)

--- a/lib/einarc/baseraid.rb
+++ b/lib/einarc/baseraid.rb
@@ -3,7 +3,7 @@ module Einarc
 	# system dependent and 99.9% of Linux distributions won't have to
 	# change it. However, replace this one with fake sysfs comes handy
 	# for testing purposes too.
-	@@sysfs = '/sys'
+  @@sysfs = '/sys'
 
 	class Error < RuntimeError
 		attr_reader :text
@@ -42,7 +42,6 @@ module Einarc
 	# * Abstract methods that should be implemented in RAID adapter modules
 	# * Misc helper methods useful for all modules
 	class BaseRaid
-    @@sysfs = '/sys'
 		attr_accessor :logical
 		attr_accessor :physical
 		attr_accessor :outstream

--- a/lib/einarc/lsi_megacli.rb
+++ b/lib/einarc/lsi_megacli.rb
@@ -61,7 +61,7 @@ module Einarc
 					when /SubVendorId/ then 'PCI subvendor ID'
 					when /SubDeviceId/ then 'PCI subproduct ID'
 					else key
-					end				
+					end
 					res[key] = val
 				end
 			}
@@ -167,16 +167,16 @@ module Einarc
 			}
 
 			# Try to find corresponding /dev-entries
-			devices = Dir.entries("#{@@sysfs}/block").select { |dev|
+			devices = Dir.entries("#{@sysfs}/block").select { |dev|
 				physical_read_file(dev, "device/model") =~ /^(MegaRAID|MR|RS2BL080|RS2BL040|SMC2108|MR9260|SRCSASLS4I|RS2WC040)/
 			}
 			devs = {}
 			devices.each { |dev|
-				if File.exist?("#{@@sysfs}/block/#{dev}/device/scsi_disk") then
-					devs[ Dir.entries("#{@@sysfs}/block/#{dev}/device/scsi_disk").collect { |ent| 
+				if File.exist?("#{@sysfs}/block/#{dev}/device/scsi_disk") then
+					devs[ Dir.entries("#{@sysfs}/block/#{dev}/device/scsi_disk").collect { |ent|
 						"#{$1}:#{$2}" if ent =~ /\d+:(\d+):(\d+):\d/}.compact.last ] = dev
 				else
-					devs[ Dir.entries("#{@@sysfs}/block/#{dev}/device").collect { |ent|
+					devs[ Dir.entries("#{@sysfs}/block/#{dev}/device").collect { |ent|
 						"#{$1}:#{$2}" if ent =~ /scsi_disk:\d+:(\d+):(\d+):\d/}.compact.last ] = dev
 				end
 			}
@@ -263,15 +263,15 @@ module Einarc
 #Coerced Size: 231.898 GB [0x1cfcc000 Sectors]
 #Firmware state: Online
 #SAS Address(0): 0x7a78a43dc6d5f6ab
-#Connected Port Number: 4(path0) 
+#Connected Port Number: 4(path0)
 #Inquiry Data:       GEK230RBSEVNRAHitachi HDP725025GLA380                 GM2OA52A
 #FDE Capable: Not Capable
 #FDE Enable: Disable
 #Secured: Unsecured
 #Locked: Unlocked
-#Foreign State: None 
-#Device Speed: Unknown 
-#Link Speed: Unknown 
+#Foreign State: None
+#Device Speed: Unknown
+#Link Speed: Unknown
 #Media Type: Hard Disk Device
 
 #Enclosure Device ID: 252
@@ -289,15 +289,15 @@ module Einarc
 #Firmware state: Unconfigured(good), Spun Up
 #SAS Address(0): 0x500000e0147a3462
 #SAS Address(1): 0x0
-#Connected Port Number: 5(path0) 
-#Inquiry Data: FUJITSU MAX3073RC       0104DQA0P7200RAB        
+#Connected Port Number: 5(path0)
+#Inquiry Data: FUJITSU MAX3073RC       0104DQA0P7200RAB
 #FDE Capable: Not Capable
 #FDE Enable: Disable
 #Secured: Unsecured
 #Locked: Unlocked
-#Foreign State: None 
-#Device Speed: Unknown 
-#Link Speed: Unknown 
+#Foreign State: None
+#Device Speed: Unknown
+#Link Speed: Unknown
 #Media Type: Hard Disk Device
 
 #Enclosure Device ID: 252
@@ -314,15 +314,15 @@ module Einarc
 #Coerced Size: 148.080 GB [0x12829000 Sectors]
 #Firmware state: Unconfigured(good), Spun Up
 #SAS Address(0): 0xf2314077a8e7136
-#Connected Port Number: 6(path0) 
-#Inquiry Data:             9RA5RXJDST3160215AS                             3.AAD   
+#Connected Port Number: 6(path0)
+#Inquiry Data:             9RA5RXJDST3160215AS                             3.AAD
 #FDE Capable: Not Capable
 #FDE Enable: Disable
 #Secured: Unsecured
 #Locked: Unlocked
-#Foreign State: None 
-#Device Speed: Unknown 
-#Link Speed: Unknown 
+#Foreign State: None
+#Device Speed: Unknown
+#Link Speed: Unknown
 #Media Type: Hard Disk Device
 
 		def _physical_list
@@ -365,10 +365,10 @@ module Einarc
 						phys[:model] = l[34..73].strip
 						phys[:serial] = l[14..33].strip
 					when "SAS"
-						#Inquiry Data: FUJITSU MAX3073RC       0104DQA0P7200RAB        
+						#Inquiry Data: FUJITSU MAX3073RC       0104DQA0P7200RAB
 						phys[:model] = l[14..21].strip + ' ' + l[22..37].strip
 						phys[:revision] = l[38..41].strip
-						phys[:serial] = l[42..61].strip				
+						phys[:serial] = l[42..61].strip
 					else
 						raise Error.new("Unknown disc type encountered: #{phys[:interface].inspect}")
 					end
@@ -460,7 +460,7 @@ module Einarc
 		def set_physical_hotspare_1(drv)
 			run("-PDHSP -Set -PhysDrv [#{drv}] #{@args}")
 		end
-		
+
 		def get_logical_stripe(num)
 			ld = _logical_list[num.to_i]
 			raise Error.new("Unknown logical disc \"#{num}\"") unless ld
@@ -507,7 +507,7 @@ module Einarc
 		end
 
 		# ======================================================================
-		
+
 		def _bbu_info
 			info = {}
 			run("-AdpBbuCmd -GetBbuDesignInfo #{@args}").each do |l|
@@ -524,11 +524,11 @@ module Einarc
 			end
 			info
 		end
-		
+
 		# ======================================================================
 
 		def _physical_smart(drv)
-			needed_smart_section_re = /START OF READ SMART DATA SECTION/ 
+			needed_smart_section_re = /START OF READ SMART DATA SECTION/
 
 			corresponding_drive = _logical_list.collect{ |ld| ld[:dev] }.last
 			raise Error.new( "You have to create at least one logical disk to get SMART info" ) unless corresponding_drive

--- a/lib/einarc/lsi_megarc.rb
+++ b/lib/einarc/lsi_megarc.rb
@@ -127,7 +127,7 @@ module Einarc
 			num = nil
 
 			# Find all corresponding devices
-			Dir.entries("#{@@sysfs}/block").select { |dev|
+			Dir.entries("#{@sysfs}/block").select { |dev|
 				physical_read_file(dev, "device/vendor") =~ /^MegaRAID/
 			}.each { |dev|
 				@dev[$1.to_i] = "/dev/#{dev}" if physical_read_file(dev, "device/model") =~ /^LD\s*(\d+) RAID/
@@ -358,7 +358,7 @@ module Einarc
 		def _bbu_info
 			raise NotImplementedError
 		end
-		
+
 		# ======================================================================
 
 		private

--- a/lib/einarc/software.rb
+++ b/lib/einarc/software.rb
@@ -104,7 +104,7 @@ module Einarc
 		end
 
 		# ======================================================================
-		
+
 		def check_detached_hotspares
 			File.open(MDSTAT_LOCATION, 'r') { |f| f.each_line { |l|
 				if l =~ MDSTAT_PATTERN
@@ -196,10 +196,10 @@ module Einarc
 				options.each { |o|
 					if o =~ /^(.*?)=(.*?)$/
 						case $1
-						when 'stripe' 
+						when 'stripe'
 							opt_cmd += "--chunk #{$2} "
 							chunk_size = $2.to_i
-						else 
+						else
 							raise Error.new("Unknown option \"#{o}\"")
 						end
 					else
@@ -217,7 +217,7 @@ module Einarc
 				raise Error.new('RAID 5 requires 3 or more discs') unless discs.size >= 3
 			when '6'
 				raise Error.new('RAID 6 requires 4 or more discs') unless discs.size >= 4
-			when '10' 
+			when '10'
 				raise Error.new('RAID 10 requires an even number of discs, but at least 4') if discs.size % 2 != 0 or discs.size < 4
 			end
 
@@ -340,7 +340,7 @@ module Einarc
 		end
 
 		def _physical_smart(drv)
-			needed_smart_section_re = /START OF READ SMART DATA SECTION/ 
+			needed_smart_section_re = /START OF READ SMART DATA SECTION/
 
 			# Determine do we need to use "-d ata" option
 			smart_output = `smartctl -A #{self.class.scsi_to_device drv}`
@@ -430,7 +430,7 @@ module Einarc
 
 		def list_sgmaps()
 			Hash[ `sg_map`.split("\n").map{ |m| m.split(/\s+/).reverse }.select{ |p| p.size > 1 } ]
-		end 
+		end
 
 		def get_physical_wwn( drv )
 			page = "0x19" # SAS SSP port control mode page
@@ -597,7 +597,7 @@ module Einarc
 
 		def raid_member?(device)
 			name = device.gsub(/^\/dev\//, '')
-			
+
 			# Check name existence in mdstat file
 			return (not File.readlines(MDSTAT_LOCATION).grep(Regexp.new(name)).empty?)
 		end
@@ -624,7 +624,7 @@ module Einarc
 
 		def active?(device)
 			name = device.gsub(/^\/dev\//, '')
-			
+
 			# Check RAID existence in mdstat file
 			return (not File.readlines(MDSTAT_LOCATION).grep(Regexp.new(name)).empty?)
 		end
@@ -659,7 +659,7 @@ module Einarc
 		def level_of(device)
 			File.readlines(MDSTAT_LOCATION).grep(%r[^#{device.gsub(/\/dev\//, '') }]).grep(MDSTAT_PATTERN) do
 				return $2.split.last.gsub('raid','')
-			end			
+			end
 		end
 
 		# Returns next free name for md device

--- a/tests_simulate
+++ b/tests_simulate
@@ -70,7 +70,7 @@ class TestRunner
 			@adapter.outstream = StringIO.new
 
 			# Fake sysfs path
-			@@sysfs = "#{@test_dir}/#{adapter_name}/sysfs"
+			@adapter.sysfs = "#{@test_dir}/#{adapter_name}/sysfs"
 
 			begin
 				Dir.new("#{@test_dir}/#{adapter_name}").sort.each { |test_name|


### PR DESCRIPTION
Einarc isn't detecting the following RAID controller, however adding additional fields to the `find_adapter_by_pciid` method has been successful on detecting new RAID card.

``` bash
09:00.0 RAID bus controller: Adaptec AAC-RAID (rev 09)

# lspci -mn output
09:00.0 "0104" "9005" "0285" -r09 "9005" "02da"
```

Also, fix for following error:

``` ruby
uninitialized class variable @@sysfs in Einarc::BaseRaid (NameError)
```

Removed the class constant inside Einarc module and moved it to `Einarc::BaseRaid` class since all adapter classes inherit BaseRaid class, and it's defined for LSI adapters mostly. 

Test suite has been updated as well to reflect the change for the @@sysfs class variable.
