### PR TITLE
UPDATE: adding alternative format to logical list

### DIFF
--- a/lib/einarc/adaptec_arcconf.rb
+++ b/lib/einarc/adaptec_arcconf.rb
@@ -173,6 +173,8 @@ module Einarc
 					end
 				when /Segment (\d+)\s*:\s*(.*?) \((\d+),(\d+)\)/
 					ld[:physical] << "#{$3}:#{$4}"
+				when /Segment (\d+)\s*:\s*(.*?) \(Controller:\d+,Enclosure:(\d+),Slot:(\d+)\)/
+					ld[:physical] << "#{$3}:#{$4}"
 				when /Dedicated Hot-Spare\s*:\s*(\d+),(\d+)/
 					ld[:physical] << "#{$1}:#{$2}"
 				when /Status of logical device\s+:\s(.+)$/


### PR DESCRIPTION
  $ arcconf getconfig 1 ld
  ...

   Logical device segment information

---

   Group 0, Segment 0                       : Present (Controller:1,Enclosure:0,Slot:1)      WD-WMAW30289850
   Group 0, Segment 1                       : Present (Controller:1,Enclosure:0,Slot:2)      WD-WMAW30069103
   Group 1, Segment 0                       : Present (Controller:1,Enclosure:0,Slot:3)      WD-WMAW30192456
   Group 1, Segment 1                       : Present (Controller:1,Enclosure:0,Slot:4)      WD-WCAW32805052

  ...

  Existing regular expression was not able to figure out which drives were members of which array.
  Adding support for format like seen above
