### PR TITLE
FIX: data type of state is string not array

### DIFF
--- a/lib/einarc/adaptec_arcconf.rb
+++ b/lib/einarc/adaptec_arcconf.rb
@@ -343,7 +343,7 @@ module Einarc
 				l[:physical].each { |pd|
 					next if %w{ failed }.include?(@physical[pd][:state])
 					next if @physical[pd][:state] == "hotspare"
-					if @physical[pd][:state].is_a?(Array)
+					if @physical[pd][:state].is_a?(String)
 						@physical[pd][:state] << i
 					else
 						@physical[pd][:state] = [ i ]


### PR DESCRIPTION
Before fix, when some phys existed their status would be overwritten with 'index' number so one would get output like

``` bash
# einarc physical list
ID      Model                    Revision       Serial                     Size     State
0:0     ATA WDC WD1003FBYX-0     01.01V02       WD-WCAW33461279       953869.00 MB  0,1
0:1     ATA WDC WD1003FBYX-0     01.01V02       WD-WCAW36018946       953869.00 MB  0,1
0:2     ATA WDC WD1003FBYX-0     01.01V02       WD-WCAW36019154       953869.00 MB  0,1
0:3     ATA WDC WD1003FBYX-0     01.01V02       WD-WCAW33512856       953869.00 MB  0,1
```

Instead

``` bash
# einarc physical list
ID      Model                    Revision       Serial                     Size     State
0:0     ATA WDC WD1003FBYX-0     01.01V02       WD-WCAW33461279       953869.00 MB  optimal
0:1     ATA WDC WD1003FBYX-0     01.01V02       WD-WCAW36018946       953869.00 MB  optimal
0:2     ATA WDC WD1003FBYX-0     01.01V02       WD-WCAW36019154       953869.00 MB  optimal
0:3     ATA WDC WD1003FBYX-0     01.01V02       WD-WCAW33512856       953869.00 MB  optimal
```
