### PR TITLE
Fix adaptec logical physical list

### DIFF
--- a/lib/einarc/adaptec_arcconf.rb
+++ b/lib/einarc/adaptec_arcconf.rb
@@ -269,17 +269,13 @@ module Einarc
 			set_physical_hotspare_0(drv)
 		end
 
-		def _logical_physical_list(ld)
-			res = []
-			_logical_list.select { |l| l[:num] == ld.to_i }[0][:physical].each { |d|
-				state = nil
-				_physical_list.each_pair { |num, drv|
-					state = "hotspare" if drv[:dedicated_to] == ld and num == d
-				}
-				res.push( { :num => d, :state => state ? state : ld } )
-			}
-			return res
-		end
+                def _logical_physical_list(ld)
+                        res = []
+                        ld.each { |l|
+                                res.push( { :num => l[:num], :state => l[:state] ? l[:state] : l } )
+                        }
+                        return res
+                end
 
 #      Device #5
 #         Device is a Hard drive

--- a/lib/einarc/baseraid.rb
+++ b/lib/einarc/baseraid.rb
@@ -221,7 +221,8 @@ module Einarc
 			end
 		end
 
-		def logical_physical_list(ld)
+		def logical_physical_list
+                        ld = _logical_list
 			if $humanize then
 				@outstream.puts "ID      State"
 				_logical_physical_list(ld).each{ |d|


### PR DESCRIPTION
```
    Now its like...
    # einarc logical pd_ls
    ID      State
    0       normal
    1       normal

    Before it was like...
    # einarc logical pd_ls
    /path/.../baseraid.rb:217:in `logical_physical_list': wrong number of arguments (0 for 1) (ArgumentError)
            from /path/../baseraid.rb:338:in `handle_method'
            from /usr/local/bin/einarc:79:in `<main>'

    It's unclear what this was supposed to do anyways, now it's displaying state
    of logical array since that's what humanized output is trying to present.

    Personally I feel naming would suggest maping between logical and physical locations
```
